### PR TITLE
Switch libmoonshot from dbus-glib to gdbus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ libmoonshot_libmoonshot_la_CPPFLAGS = \
 
 libmoonshot_libmoonshot_la_SOURCES = libmoonshot/libmoonshot-common.c
 
-libmoonshot_libmoonshot_la_LIBADD = $(libmoonshot_LIBS) $(GLIB_LIBS)
+libmoonshot_libmoonshot_la_LIBADD = $(libmoonshot_LIBS)
 libmoonshot_libmoonshot_la_LDFLAGS = -no-undefined -version-info 1:0:0
 
 include_HEADERS = libmoonshot/libmoonshot.h
@@ -214,8 +214,8 @@ examples_service_selection_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)
 examples_service_selection_LDADD = ${top_builddir}/libmoonshot/libmoonshot.la $(moonshot_LIBS)
 
 examples_client_SOURCES = examples/client.c
-examples_client_CPPFLAGS = $(libmoonshot_CFLAGS) $(AM_CPPFLAGS) $(GLIB_CFLAGS)
-examples_client_LDADD = ${top_builddir}/libmoonshot/libmoonshot.la $(GLIB_LIBS)
+examples_client_CPPFLAGS = $(libmoonshot_CFLAGS) $(AM_CPPFLAGS)
+examples_client_LDADD = $(libmoonshot_LIBS) ${top_builddir}/libmoonshot/libmoonshot.la
 
 tests_basic_SOURCES = tests/basic.c
 tests_basic_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ libmoonshot_libmoonshot_la_CPPFLAGS = \
 
 libmoonshot_libmoonshot_la_SOURCES = libmoonshot/libmoonshot-common.c
 
-libmoonshot_libmoonshot_la_LIBADD = $(libmoonshot_LIBS)
+libmoonshot_libmoonshot_la_LIBADD = $(libmoonshot_LIBS) $(GLIB_LIBS)
 libmoonshot_libmoonshot_la_LDFLAGS = -no-undefined -version-info 1:0:0
 
 include_HEADERS = libmoonshot/libmoonshot.h
@@ -214,8 +214,8 @@ examples_service_selection_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)
 examples_service_selection_LDADD = ${top_builddir}/libmoonshot/libmoonshot.la $(moonshot_LIBS)
 
 examples_client_SOURCES = examples/client.c
-examples_client_CPPFLAGS = $(libmoonshot_CFLAGS) $(AM_CPPFLAGS)
-examples_client_LDADD = ${top_builddir}/libmoonshot/libmoonshot.la
+examples_client_CPPFLAGS = $(libmoonshot_CFLAGS) $(AM_CPPFLAGS) $(GLIB_CFLAGS)
+examples_client_LDADD = ${top_builddir}/libmoonshot/libmoonshot.la $(GLIB_LIBS)
 
 tests_basic_SOURCES = tests/basic.c
 tests_basic_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
- 
+
 SUBDIRS = po
 
 moonshotsysconfdir=${sysconfdir}/moonshot
@@ -42,7 +42,7 @@ AM_VALAFLAGS = -g \
 
 libmoonshot_libmoonshot_la_CPPFLAGS = \
         $(libmoonshot_CFLAGS) \
-        $(AM_CPPFLAGS) 
+        $(AM_CPPFLAGS)
 
 libmoonshot_libmoonshot_la_SOURCES = libmoonshot/libmoonshot-common.c
 
@@ -84,7 +84,7 @@ src_moonshot_webp_SOURCES = \
 
 
 src_moonshot_VALAFLAGS = --pkg $(GTK_VERSION) --pkg $(GEE_VERSION)   $(AM_VALAFLAGS)
-src_moonshot_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)  
+src_moonshot_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)
 src_moonshot_LDADD = $(moonshot_LIBS)
 src_moonshot_LDFLAGS = -g -O0 $(MOONSHOT_LOG_LIBS)
 
@@ -98,7 +98,7 @@ if OS_WIN32
 
 src_moonshot_CFLAGS = -mwindows
 src_moonshot_webp_CFLAGS = -mconsole
-    
+
 AM_CPPFLAGS += -DOS_WIN32
 AM_VALAFLAGS += --define=OS_WIN32
 
@@ -178,7 +178,7 @@ dbusservice_DATA = $(dbusservice_in_files:.service.mac=.service)
 else
 dbusservice_in_files = org.janet.Moonshot.service.in
 dbusservice_DATA = $(dbusservice_in_files:.service.in=.service)
-endif 
+endif
 
 # Rule to make the service file with bindir expanded
 $(dbusservice_DATA): $(dbusservice_in_files) Makefile
@@ -188,18 +188,10 @@ libmoonshot_libmoonshot_la_SOURCES += libmoonshot/libmoonshot-dbus.c
 
 CLEANFILES = $(dbusservice_DATA)  src_moonshot_vala.stamp src_moonshot_vala.stamp-t
 
-if IPC_DBUS_GLIB
-AM_VALAFLAGS += \
-	--pkg dbus-glib-1 \
-	--define=IPC_DBUS_GLIB \
-	--define=IPC_DBUS
-AM_CPPFLAGS += -DIPC_DBUS_GLIB
-else
 AM_VALAFLAGS += \
 	--pkg gio-2.0 \
 	--define=IPC_GDBUS \
 	--define=IPC_DBUS
-endif
 endif
 if GIO_VAPI_USES_ARRAYS
 AM_VALAFLAGS += --define=GIO_VAPI_USES_ARRAYS
@@ -271,7 +263,7 @@ endif
 if  OS_MACOS
 ## Mac-specific targets
 
-## 1. Icons. 
+## 1. Icons.
 
 icons:
 	mkdir -p share/icons

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,6 @@ PKG_CHECK_MODULES(moonshot,[
 ])
 
 PKG_CHECK_MODULES(libmoonshot,[
-        glib-2.0 >= 2.22
         $CLIENT_IPC_MODULE
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,8 +38,8 @@ case "$host" in
     SERVER_IPC_MODULE="msrpc-glib2-1.0"
     CLIENT_IPC_MODULE="msrpc-mingw-1.0"
     ;;
-    
-  *darwin*) 
+
+  *darwin*)
     win32=no
     macos=yes
     linux=no
@@ -49,9 +49,9 @@ case "$host" in
     # because Vala drops support for it, but as it ships with DBus there is very
     # little danger of it being dropped by distros any time soon.
     CLIENT_IPC_MODULE="dbus-glib-1"
-	SERVER_IPC_MODULE="dbus-glib-1"   
-	
-	PKG_CHECK_MODULES([MAC], 
+	SERVER_IPC_MODULE="dbus-glib-1"
+
+	PKG_CHECK_MODULES([MAC],
 			[gtk-mac-integration >= 1.0.1]
 	)
 
@@ -83,7 +83,7 @@ PKG_CHECK_MODULES([GTK],
             [PKG_CHECK_MODULES([GTK],
                         [gtk+-2.0 >= 2.18],
                         [GTK_VERSION="gtk+-2.0"]
-            )]                            
+            )]
 )
 AC_SUBST(GTK_VERSION)
 
@@ -96,7 +96,7 @@ PKG_CHECK_MODULES([LOG4VALA],
             [PKG_CHECK_MODULES([LOG4VALA],
                         [log4vala-0.1],
                         [LOG4VALA_VERSION="log4vala-0.1"]
-            )]                            
+            )]
 )
 AC_SUBST(LOG4VALA_VERSION)
 fi
@@ -110,7 +110,7 @@ PKG_CHECK_MODULES([LIB_GEE],
             [PKG_CHECK_MODULES([LIB_GEE],
                         [gee-1.0 >= 0.5],
                         [GEE_VERSION="gee-1.0"]
-            )]                            
+            )]
 )
 AC_SUBST(GEE_VERSION)
 
@@ -131,7 +131,6 @@ AM_CONDITIONAL([OS_MACOS], [test "$macos" = "yes"])
 
 AM_CONDITIONAL([IPC_MSRPC], [test "$SERVER_IPC_MODULE" = "msrpc-glib2-1.0"])
 AM_CONDITIONAL([IPC_DBUS], [test "$SERVER_IPC_MODULE" != "msrpc-glib2-1.0"])
-AM_CONDITIONAL([IPC_DBUS_GLIB], [test "$SERVER_IPC_MODULE" = "dbus-glib-1"])
 AM_CONDITIONAL([IPC_GDBUS], [test "$SERVER_IPC_MODULE" = "gio-2.0"])
 
 vala_version=`$VALAC --version | sed 's/Vala  *//'`
@@ -140,20 +139,6 @@ AS_VERSION_COMPARE(["$vala_version"], [0.11.1],
   [gio_vapi_uses_arrays="yes"],
   [gio_vapi_uses_arrays="yes"])
 AM_CONDITIONAL([GIO_VAPI_USES_ARRAYS], [test "$gio_vapi_uses_arrays" = "yes"])
-if test "$SERVER_IPC_MODULE" = "dbus-glib-1"; then
-  AC_MSG_CHECKING([$VALAC is no greater than 0.12.1])
-  AS_VERSION_COMPARE([0.12.2], ["$vala_version"],
-    [vala_supports_dbus_glib="no"],
-    [vala_supports_dbus_glib="no"],
-    [vala_supports_dbus_glib="yes"])
-
-  AC_MSG_RESULT([$vala_supports_dbus_glib])
-  if test "$vala_supports_dbus_glib" = "no"; then
-    AC_MSG_ERROR([
-*** Vala 0.12.1 or earlier is required for dbus-glib support. Newer versions
-*** require that you have GLib 2.26 or newer (for GDBus support).])
-  fi
-fi
 
 if test "$SERVER_IPC_MODULE" = "msrpc-glib2-1.0"; then
   # MS RPC utilities

--- a/configure.ac
+++ b/configure.ac
@@ -44,12 +44,9 @@ case "$host" in
     macos=yes
     linux=no
 
-    # We require dbus-glib for the client library even if we are using GDBus
-    # in the server. The reason we can't always use dbus-glib in the server is
-    # because Vala drops support for it, but as it ships with DBus there is very
-    # little danger of it being dropped by distros any time soon.
-    CLIENT_IPC_MODULE="dbus-glib-1"
-	SERVER_IPC_MODULE="dbus-glib-1"
+    # Use gdbus for everything
+    CLIENT_IPC_MODULE="gio-2.0"
+	SERVER_IPC_MODULE="gio-2.0"
 
 	PKG_CHECK_MODULES([MAC],
 			[gtk-mac-integration >= 1.0.1]
@@ -61,16 +58,9 @@ case "$host" in
     win32=no
     linux=yes
 
-    # We require dbus-glib for the client library even if we are using GDBus
-    # in the server. The reason we can't always use dbus-glib in the server is
-    # because Vala drops support for it, but as it ships with DBus there is very
-    # little danger of it being dropped by distros any time soon.
-    CLIENT_IPC_MODULE="dbus-glib-1"
-    PKG_CHECK_MODULES([GDBUS],
-            [gio-2.0 >= 2.26],
-            [SERVER_IPC_MODULE="gio-2.0"],
-            [SERVER_IPC_MODULE="dbus-glib-1"]
-    )
+    # Now use gdbus for everything, so no test
+    CLIENT_IPC_MODULE="gio-2.0"
+    SERVER_IPC_MODULE="gio-2.0"
 
     ;;
 esac
@@ -243,6 +233,7 @@ PKG_CHECK_MODULES(moonshot,[
 ])
 
 PKG_CHECK_MODULES(libmoonshot,[
+        glib-2.0 >= 2.22
         $CLIENT_IPC_MODULE
 ])
 

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -37,11 +37,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-#include <dbus/dbus-glib.h>
-#include <dbus/dbus.h>
-#include <dbus/dbus-glib-lowlevel.h>
+#include <gio/gio.h>
 #include <glib/gspawn.h>
-
 
 #include "libmoonshot.h"
 #include "libmoonshot-common.h"
@@ -52,15 +49,14 @@
 #define MOONSHOT_DBUS_NAME "org.janet.Moonshot"
 #define MOONSHOT_DBUS_PATH "/org/janet/moonshot"
 
-/* This library is overly complicated currently due to the requirement
- * that it work on Debian Squeeze - this has GLib 2.24 which requires us
- * to use dbus-glib instead of GDBus. If/when this requirement is
- * dropped the DBus version of the library can be greatly simplified.
- */
-
-/* Note that ideally this library would not depend on GLib. This would be
+/* Original comment was:
+ * Note that ideally this library would not depend on GLib. This would be
  * possible using libdbus directly and running our own message loop while
  * waiting for calls.
+ *
+ * As of June 2018, it's unclear that using libdbus directly is a good idea.
+ * Its documentation strongly encourages use of higher-level bindings.
+ * I don't know yet whether we're in an exceptional situation.
  */
 
 void moonshot_free (void *data)
@@ -71,15 +67,13 @@ static char *moonshot_launch_argv[] = {
   MOONSHOT_LAUNCH_SCRIPT, NULL
 };
 
-static DBusGConnection *dbus_launch_moonshot()
+static GDBusConnection *dbus_launch_moonshot()
 {
-    DBusGConnection *connection = NULL;
+    GDBusConnection *connection = NULL;
     GError *error = NULL;
-    DBusError dbus_error;
     GPid child_pid;
     gint fd_stdin = -1, fd_stdout = -1;
     ssize_t addresslen;
-    dbus_error_init(&dbus_error);
     char dbus_address[1024];
 
     if (g_spawn_async_with_pipes( NULL /*cwd*/,
@@ -94,22 +88,26 @@ static DBusGConnection *dbus_launch_moonshot()
     close(fd_stdout);
     /* we require at least 2 octets of address because we trim the newline*/
     if (addresslen <= 1) {
-    fail: dbus_error_free(&dbus_error);
+    fail:
       if (connection != NULL)
-	dbus_g_connection_unref(connection);
+	g_object_unref(connection);
       close(fd_stdin);
       g_spawn_close_pid(child_pid);
       return NULL;
     }
     dbus_address[addresslen-1] = '\0';
-    connection = dbus_g_connection_open(dbus_address, &error);
+    /* TODO verify that the flags here are correct */
+  connection = g_dbus_connection_new_for_address_sync(dbus_address,
+                          G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT
+                            | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+                          NULL, /* observer */
+                          NULL, /* cancellable */
+                          &error);
     if (error) {
       g_error_free(error);
       goto fail;
     }
-    if (!dbus_bus_register(dbus_g_connection_get_connection(connection),
-			   &dbus_error))
-      goto fail;
+
 	return connection;
 }
 
@@ -124,23 +122,17 @@ static int is_setid()
   return 0;
 }
 
-static DBusGProxy *dbus_connect (MoonshotError **error)
+static GDBusProxy *dbus_connect (MoonshotError **error)
 {
-    DBusConnection  *dbconnection;
-    DBusError        dbus_error;
-    DBusGConnection *connection;
-    DBusGProxy      *g_proxy;
+    GDBusConnection *connection;
+    GDBusProxy      *g_proxy;
     GError          *g_error = NULL;
-    dbus_bool_t      name_has_owner;
 
     g_return_val_if_fail (*error == NULL, NULL);
 
-    dbus_error_init (&dbus_error);
+    /* Check for moonshot server and start the service if possible. */
 
-    /* Check for moonshot server and start the service if possible. We use
-     * libdbus here because dbus-glib doesn't handle autostarting the service.
-     * If/when we move to GDBus this code can become a one-liner.
-     */
+    /* TODO: is this still necessary with gdbus? */
 
     if (is_setid()) {
         *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
@@ -148,10 +140,12 @@ static DBusGProxy *dbus_connect (MoonshotError **error)
         return NULL;
     }
 
-    connection = dbus_g_bus_get (DBUS_BUS_SESSION, &g_error);
+    connection = g_bus_get_sync(G_BUS_TYPE_SESSION,
+                                NULL, /* no cancellable */
+                                &g_error);
 
-    if (g_error_matches(g_error, DBUS_GERROR, DBUS_GERROR_NOT_SUPPORTED)) {
-        /*Generally this means autolaunch failed because probably DISPLAY is unset*/
+    if (g_error_matches(g_error, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED)) {
+        /* Generally this means autolaunch failed because probably DISPLAY is unset*/
         connection = dbus_launch_moonshot();
         if (connection != NULL) {
             g_error_free(g_error);
@@ -166,51 +160,19 @@ static DBusGProxy *dbus_connect (MoonshotError **error)
         return NULL;
     }
 
-    dbconnection = dbus_g_connection_get_connection(connection);
-    name_has_owner  = dbus_bus_name_has_owner (dbconnection,
-                                               MOONSHOT_DBUS_NAME,
-                                               &dbus_error);
-
-    if (dbus_error_is_set (&dbus_error)) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     "DBus error: %s",
-                                     dbus_error.message);
-        dbus_error_free (&dbus_error);
-        return NULL;
-    }
-
-    if (! name_has_owner) {
-        dbus_bus_start_service_by_name (dbconnection,
-                                        MOONSHOT_DBUS_NAME,
-                                        0,
-                                        NULL,
-                                        &dbus_error);
-
-        if (dbus_error_is_set (&dbus_error)) {
-            if (strcmp (dbus_error.name + 27, "ServiceUnknown") == 0) {
-                /* Missing .service file; the moonshot-ui install is broken */
-                *error = moonshot_error_new (MOONSHOT_ERROR_UNABLE_TO_START_SERVICE,
-                                             "The Moonshot service was not found. "
-                                             "Please make sure that moonshot-ui is "
-                                             "correctly installed.");
-            } else {
-                *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                             "DBus error: %s",
-                                             dbus_error.message);
-            }
-            dbus_error_free (&dbus_error);
-            return NULL;
-        }
-    }
-
-    /* Now the service should be running */
-    g_error = NULL;
-
-    g_proxy = dbus_g_proxy_new_for_name_owner (connection,
-                                               MOONSHOT_DBUS_NAME,
-                                               MOONSHOT_DBUS_PATH,
-                                               MOONSHOT_DBUS_NAME,
-                                               &g_error);
+    /* This will autostart the service if MOONSHOT_DBUS_NAME is a well-known name.
+     * To inhibit that behavior, add G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START and/or
+     * G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START_AT_CONSTRUCTION
+     */
+    g_proxy = g_dbus_proxy_new_sync(
+                    connection,
+                    G_DBUS_PROXY_FLAGS_NONE, /* TODO check flags */
+                    NULL, /* TODO define our expected interface */
+                    MOONSHOT_DBUS_NAME,
+                    MOONSHOT_DBUS_PATH,
+                    MOONSHOT_DBUS_NAME,
+                    NULL, /* no cancellable */
+                    &g_error);
 
     if (g_error != NULL) {
         *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
@@ -223,9 +185,9 @@ static DBusGProxy *dbus_connect (MoonshotError **error)
     return g_proxy;
 }
 
-static DBusGProxy *get_dbus_proxy (MoonshotError **error)
+static GDBusProxy *get_dbus_proxy (MoonshotError **error)
 {
-    static DBusGProxy    *dbus_proxy = NULL;
+    static GDBusProxy    *dbus_proxy = NULL;
     static GStaticMutex   init_lock = G_STATIC_MUTEX_INIT;
 
     g_static_mutex_lock (&init_lock);
@@ -234,10 +196,12 @@ static DBusGProxy *get_dbus_proxy (MoonshotError **error)
         /* Make sure GObject is initialised, in case we are the only user
          * of GObject in the process
          */
-        g_type_init ();
+        g_type_init (); /* harmless but deprecated, may still be needed on CentOS 6 */
         dbus_proxy = dbus_connect (error);
     }
 
+    /* TODO I think this should only be called if we did not just call dbus_connect()
+     * otherwise ref count will always be n_refs + 1 */
     if (dbus_proxy != NULL)
         g_object_ref (dbus_proxy);
 
@@ -258,34 +222,30 @@ int moonshot_get_identity (const char     *nai,
                            MoonshotError **error)
 {
     GError     *g_error = NULL;
-    DBusGProxy *dbus_proxy;
-    int         success;
+    GDBusProxy *dbus_proxy;
+    gboolean    success;
+    GVariant   *result = NULL;
 
     dbus_proxy = get_dbus_proxy (error);
 
     if (*error != NULL)
         return FALSE;
 
-    g_return_val_if_fail (DBUS_IS_G_PROXY (dbus_proxy), FALSE);
+    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
 
-    dbus_g_proxy_call_with_timeout (dbus_proxy,
-                       "GetIdentity",
-				    INFINITE_TIMEOUT,
-				    &g_error,
-                       G_TYPE_STRING, nai,
-                       G_TYPE_STRING, password,
-                       G_TYPE_STRING, service,
-                       G_TYPE_INVALID,
-                       G_TYPE_STRING, nai_out,
-                       G_TYPE_STRING, password_out,
-                       G_TYPE_STRING, server_certificate_hash_out,
-                       G_TYPE_STRING, ca_certificate_out,
-                       G_TYPE_STRING, subject_name_constraint_out,
-                       G_TYPE_STRING, subject_alt_name_constraint_out,
-                       G_TYPE_BOOLEAN, &success,
-                       G_TYPE_INVALID);
-
-    g_object_unref (dbus_proxy);
+    /* This method consumes the floating parameter GVariant.
+     * Returns null if g_error is set. */
+  result = g_dbus_proxy_call_sync(dbus_proxy,
+                                  "GetIdentity",
+                                  g_variant_new("(sss)",
+                                                nai,
+                                                password,
+                                                service),
+                                  G_DBUS_CALL_FLAGS_NONE,
+                                  G_MAXINT, /* infinite timeout */
+                                  NULL, /* no cancellable */
+                                  &g_error);
+    g_object_unref(dbus_proxy);
 
     if (g_error != NULL) {
         *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
@@ -293,11 +253,24 @@ int moonshot_get_identity (const char     *nai,
         return FALSE;
     }
 
+    /* unpack results - allocates space for strings */
+    g_variant_get(result,
+                  "(ssssssb)",
+                  nai_out,
+                  password_out,
+                  server_certificate_hash_out,
+                  ca_certificate_out,
+                  subject_name_constraint_out,
+                  subject_alt_name_constraint_out,
+                  &success);
+    g_variant_unref(result);
+
     if (success == FALSE) {
         *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
                                      "No identity was returned by the Moonshot "
                                      "user interface.");
-        return FALSE;
+      /* TODO do we need to free the strings? */
+      return FALSE;
     }
 
     return TRUE;
@@ -312,29 +285,24 @@ int moonshot_get_default_identity (char          **nai_out,
                                    MoonshotError **error)
 {
     GError     *g_error = NULL;
-    DBusGProxy *dbus_proxy;
-    int         success = FALSE;
+    GDBusProxy *dbus_proxy;
+    gboolean    success = FALSE;
+    GVariant   *result = NULL;
 
     dbus_proxy = get_dbus_proxy (error);
 
     if (*error != NULL)
         return FALSE;
 
-    g_return_val_if_fail (DBUS_IS_G_PROXY (dbus_proxy), FALSE);
+    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
 
-    dbus_g_proxy_call_with_timeout (dbus_proxy,
-                       "GetDefaultIdentity",
-				    INFINITE_TIMEOUT,
-                       &g_error,
-                       G_TYPE_INVALID,
-                       G_TYPE_STRING, nai_out,
-                       G_TYPE_STRING, password_out,
-                       G_TYPE_STRING, server_certificate_hash_out,
-                       G_TYPE_STRING, ca_certificate_out,
-                       G_TYPE_STRING, subject_name_constraint_out,
-                       G_TYPE_STRING, subject_alt_name_constraint_out,
-                       G_TYPE_BOOLEAN, &success,
-                       G_TYPE_INVALID);
+  result = g_dbus_proxy_call_sync(dbus_proxy,
+                                  "GetDefaultIdentity",
+				                          NULL, /* no parameters */
+                                  G_DBUS_CALL_FLAGS_NONE,
+                                  G_MAXINT, /* infinite timeout */
+                                  NULL, /* No cancellable */
+                                  &g_error);
 
     g_object_unref (dbus_proxy);
 
@@ -344,10 +312,23 @@ int moonshot_get_default_identity (char          **nai_out,
         return FALSE;
     }
 
-    if (success == FALSE) {
+    /* unpack results - allocates space for strings */
+  g_variant_get(result,
+                "(ssssssb)",
+                nai_out,
+                password_out,
+                server_certificate_hash_out,
+                ca_certificate_out,
+                subject_name_constraint_out,
+                subject_alt_name_constraint_out,
+                &success);
+  g_variant_unref(result);
+
+  if (success == FALSE) {
         *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
                                      "No identity was returned by the Moonshot "
                                      "user interface.");
+        /* TODO do we need to free the strings? */
         return FALSE;
     }
 
@@ -372,19 +353,20 @@ int moonshot_install_id_card (const char     *display_name,
                               MoonshotError **error)
 {
     GError      *g_error = NULL;
-    DBusGProxy  *dbus_proxy;
-    int          success = FALSE;
+    GDBusProxy  *dbus_proxy;
+    gboolean     success = FALSE;
     int          i;
     const char **rules_patterns_strv,
                **rules_always_confirm_strv,
                **services_strv;
+    GVariant    *result = NULL;
 
     dbus_proxy = get_dbus_proxy (error);
 
     if (*error != NULL)
         return FALSE;
 
-    g_return_val_if_fail (DBUS_IS_G_PROXY (dbus_proxy), FALSE);
+    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
     g_return_val_if_fail (rules_patterns_length == rules_always_confirm_length, FALSE);
 
     /* Marshall array and struct parameters for DBus */
@@ -404,25 +386,26 @@ int moonshot_install_id_card (const char     *display_name,
     rules_always_confirm_strv[rules_patterns_length] = NULL;
     services_strv[services_length] = NULL;
 
-    dbus_g_proxy_call (dbus_proxy,
-                       "InstallIdCard",
-                       &g_error,
-                       G_TYPE_STRING, display_name,
-                       G_TYPE_STRING, user_name,
-                       G_TYPE_STRING, password,
-                       G_TYPE_STRING, realm,
-                       G_TYPE_STRV, rules_patterns_strv,
-                       G_TYPE_STRV, rules_always_confirm_strv,
-                       G_TYPE_STRV, services_strv,
-                       G_TYPE_STRING, ca_cert,
-                       G_TYPE_STRING, subject,
-                       G_TYPE_STRING, subject_alt,
-                       G_TYPE_STRING, server_cert,
-                       G_TYPE_INT, force_flat_file_store,
-                       G_TYPE_INVALID,
-                       G_TYPE_BOOLEAN, &success,
-                       G_TYPE_INVALID);
-
+    /* '^as' in the variant format string corresponds to the strv type */
+    result = g_dbus_proxy_call_sync(dbus_proxy,
+                                    "InstallIdCard",
+                                    g_variant_new("(ssss^as^as^asssssi)",
+                                                  display_name,
+                                                  user_name,
+                                                  password,
+                                                  realm,
+                                                  rules_patterns_strv,
+                                                  rules_always_confirm_strv,
+                                                  services_strv,
+                                                  ca_cert,
+                                                  subject,
+                                                  subject_alt,
+                                                  server_cert,
+                                                  force_flat_file_store),
+                                    G_DBUS_CALL_FLAGS_NONE,
+                                    G_MAXINT, /* infinite timeout */
+                                    NULL, /* no cancellable */
+                                    &g_error);
     g_object_unref (dbus_proxy);
     g_free(rules_patterns_strv);
     g_free(rules_always_confirm_strv);
@@ -434,6 +417,9 @@ int moonshot_install_id_card (const char     *display_name,
         return FALSE;
     }
 
+    g_variant_get(result, "b", &success);
+    g_variant_unref(result);
+
     return success;
 }
 
@@ -444,18 +430,19 @@ int moonshot_confirm_ca_certificate (const char           *identity_name,
                                      MoonshotError       **error)
 {
     GError     *g_error = NULL;
-    int         success = 99;
-    int         confirmed = 99;
+    gboolean    success = FALSE;
+    int         confirmed = 99; /* TODO is this for debugging or a meaningful value? */
     char        hash_str[65];
-    DBusGProxy *dbus_proxy = get_dbus_proxy (error);
+    GDBusProxy *dbus_proxy = get_dbus_proxy (error);
     int         out = 0;
     int         i;
+    GVariant   *result = NULL;
 
     if (*error != NULL) {
         return FALSE;
     }
 
-    g_return_val_if_fail (DBUS_IS_G_PROXY (dbus_proxy), FALSE);
+    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
 
     /* Convert hash byte array to string */
     out = 0;
@@ -464,18 +451,16 @@ int moonshot_confirm_ca_certificate (const char           *identity_name,
         out += 2;
     }
 
-    dbus_g_proxy_call_with_timeout (dbus_proxy,
+    result = g_dbus_proxy_call_sync(dbus_proxy,
                                     "ConfirmCaCertificate",
-                                    INFINITE_TIMEOUT,
-                                    &g_error,
-                                    G_TYPE_STRING, identity_name,
-                                    G_TYPE_STRING, realm,
-                                    G_TYPE_STRING, hash_str,
-                                    G_TYPE_INVALID,
-                                    G_TYPE_INT,   &confirmed,
-                                    G_TYPE_BOOLEAN, &success,
-                                    G_TYPE_INVALID);
-
+                                    g_variant_new("(sss)",
+                                                  identity_name,
+                                                  realm,
+                                                  hash_str),
+                                    G_DBUS_CALL_FLAGS_NONE,
+                                    G_MAXINT, /* infinite timeout */
+                                    NULL, /* no cancellable */
+                                    &g_error);
     g_object_unref (dbus_proxy);
 
     if (g_error != NULL) {
@@ -484,5 +469,8 @@ int moonshot_confirm_ca_certificate (const char           *identity_name,
         return FALSE;
     }
 
-    return (int) confirmed;
+    g_variant_get(result, "(ib)", &confirmed, &success);
+    g_variant_unref(result);
+
+    return confirmed;
 }

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -144,7 +144,8 @@ static GDBusProxy *dbus_connect (MoonshotError **error)
                               NULL, /* no cancellable */
                               &g_error);
 
-  if (g_error_matches(g_error, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED)) {
+  if (g_error_matches(g_error, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED) ||
+      g_error_matches(g_error, G_DBUS_ERROR, G_DBUS_ERROR_SPAWN_EXEC_FAILED)) {
     /* Generally this means autolaunch failed because probably DISPLAY is unset*/
     connection = dbus_launch_moonshot();
     if (connection != NULL) {

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -81,7 +81,7 @@ static DBusGConnection *dbus_launch_moonshot()
     ssize_t addresslen;
     dbus_error_init(&dbus_error);
     char dbus_address[1024];
-  
+
     if (g_spawn_async_with_pipes( NULL /*cwd*/,
 				  moonshot_launch_argv, NULL /*environ*/,
 				  0 /*flags*/, NULL /*setup*/, NULL,
@@ -116,7 +116,7 @@ static DBusGConnection *dbus_launch_moonshot()
 static int is_setid()
 {
 #ifdef HAVE_GETEUID
-  if ((getuid() != geteuid()) || 
+  if ((getuid() != geteuid()) ||
       (getgid() != getegid())) {
     return 1;
   }
@@ -147,36 +147,24 @@ static DBusGProxy *dbus_connect (MoonshotError **error)
 	                             "Cannot use IPC while setid");
         return NULL;
     }
-#ifdef IPC_DBUS_GLIB
-    if (getenv("DISPLAY")==NULL) {
-        connection = dbus_launch_moonshot();
-        if (connection == NULL) {
-            *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                         "Headless dbus launch failed");
-            return NULL;
-        }
-    } else
-#endif
-    {
-        connection = dbus_g_bus_get (DBUS_BUS_SESSION, &g_error);
 
-        if (g_error_matches(g_error, DBUS_GERROR, DBUS_GERROR_NOT_SUPPORTED)) {
-            /*Generally this means autolaunch failed because probably DISPLAY is unset*/
-            connection = dbus_launch_moonshot();
-            if (connection != NULL) {
-                g_error_free(g_error);
-                g_error = NULL;
-            }
-        }
-        if (g_error != NULL) {
-            *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                         "DBus error: %s",
-                                         g_error->message);
-            g_error_free (g_error);
-            return NULL;
+    connection = dbus_g_bus_get (DBUS_BUS_SESSION, &g_error);
+
+    if (g_error_matches(g_error, DBUS_GERROR, DBUS_GERROR_NOT_SUPPORTED)) {
+        /*Generally this means autolaunch failed because probably DISPLAY is unset*/
+        connection = dbus_launch_moonshot();
+        if (connection != NULL) {
+            g_error_free(g_error);
+            g_error = NULL;
         }
     }
-
+    if (g_error != NULL) {
+        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                     "DBus error: %s",
+                                     g_error->message);
+        g_error_free (g_error);
+        return NULL;
+    }
 
     dbconnection = dbus_g_connection_get_connection(connection);
     name_has_owner  = dbus_bus_name_has_owner (dbconnection,
@@ -232,7 +220,7 @@ static DBusGProxy *dbus_connect (MoonshotError **error)
         return NULL;
     }
 
-    return g_proxy; 
+    return g_proxy;
 }
 
 static DBusGProxy *get_dbus_proxy (MoonshotError **error)

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -61,54 +61,54 @@
 
 void moonshot_free (void *data)
 {
-    g_free (data);
+  g_free (data);
 }
 static char *moonshot_launch_argv[] = {
-  MOONSHOT_LAUNCH_SCRIPT, NULL
+    MOONSHOT_LAUNCH_SCRIPT, NULL
 };
 
 static GDBusConnection *dbus_launch_moonshot()
 {
-    GDBusConnection *connection = NULL;
-    GError *error = NULL;
-    GPid child_pid;
-    gint fd_stdin = -1, fd_stdout = -1;
-    ssize_t addresslen;
-    char dbus_address[1024];
+  GDBusConnection *connection = NULL;
+  GError *error = NULL;
+  GPid child_pid;
+  gint fd_stdin = -1, fd_stdout = -1;
+  ssize_t addresslen;
+  char dbus_address[1024];
 
-    if (g_spawn_async_with_pipes( NULL /*cwd*/,
-				  moonshot_launch_argv, NULL /*environ*/,
-				  0 /*flags*/, NULL /*setup*/, NULL,
-				  &child_pid, &fd_stdin, &fd_stdout,
-				  NULL /*stderr*/, NULL /*error*/) == 0 ) {
-      return NULL;
-    }
+  if (g_spawn_async_with_pipes( NULL /*cwd*/,
+                                moonshot_launch_argv, NULL /*environ*/,
+                                0 /*flags*/, NULL /*setup*/, NULL,
+                                &child_pid, &fd_stdin, &fd_stdout,
+                                NULL /*stderr*/, NULL /*error*/) == 0 ) {
+    return NULL;
+  }
 
-    addresslen = read( fd_stdout, dbus_address, sizeof dbus_address);
-    close(fd_stdout);
-    /* we require at least 2 octets of address because we trim the newline*/
-    if (addresslen <= 1) {
-    fail:
-      if (connection != NULL)
-	g_object_unref(connection);
-      close(fd_stdin);
-      g_spawn_close_pid(child_pid);
-      return NULL;
-    }
-    dbus_address[addresslen-1] = '\0';
-    /* TODO verify that the flags here are correct */
+  addresslen = read( fd_stdout, dbus_address, sizeof dbus_address);
+  close(fd_stdout);
+  /* we require at least 2 octets of address because we trim the newline*/
+  if (addresslen <= 1) {
+fail:
+    if (connection != NULL)
+      g_object_unref(connection);
+    close(fd_stdin);
+    g_spawn_close_pid(child_pid);
+    return NULL;
+  }
+  dbus_address[addresslen-1] = '\0';
+  /* TODO verify that the flags here are correct */
   connection = g_dbus_connection_new_for_address_sync(dbus_address,
-                          G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT
-                            | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
-                          NULL, /* observer */
-                          NULL, /* cancellable */
-                          &error);
-    if (error) {
-      g_error_free(error);
-      goto fail;
-    }
+                                                      G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT
+                                                      | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+                                                      NULL, /* observer */
+                                                      NULL, /* cancellable */
+                                                      &error);
+  if (error) {
+    g_error_free(error);
+    goto fail;
+  }
 
-	return connection;
+  return connection;
 }
 
 static int is_setid()
@@ -124,90 +124,90 @@ static int is_setid()
 
 static GDBusProxy *dbus_connect (MoonshotError **error)
 {
-    GDBusConnection *connection;
-    GDBusProxy      *g_proxy;
-    GError          *g_error = NULL;
+  GDBusConnection *connection;
+  GDBusProxy      *g_proxy;
+  GError          *g_error = NULL;
 
-    g_return_val_if_fail (*error == NULL, NULL);
+  g_return_val_if_fail (*error == NULL, NULL);
 
-    /* Check for moonshot server and start the service if possible. */
+  /* Check for moonshot server and start the service if possible. */
 
-    /* TODO: is this still necessary with gdbus? */
+  /* TODO: is this still necessary with gdbus? */
 
-    if (is_setid()) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-	                             "Cannot use IPC while setid");
-        return NULL;
+  if (is_setid()) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 "Cannot use IPC while setid");
+    return NULL;
+  }
+
+  connection = g_bus_get_sync(G_BUS_TYPE_SESSION,
+                              NULL, /* no cancellable */
+                              &g_error);
+
+  if (g_error_matches(g_error, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED)) {
+    /* Generally this means autolaunch failed because probably DISPLAY is unset*/
+    connection = dbus_launch_moonshot();
+    if (connection != NULL) {
+      g_error_free(g_error);
+      g_error = NULL;
     }
+  }
+  if (g_error != NULL) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 "DBus error: %s",
+                                 g_error->message);
+    g_error_free (g_error);
+    return NULL;
+  }
 
-    connection = g_bus_get_sync(G_BUS_TYPE_SESSION,
-                                NULL, /* no cancellable */
-                                &g_error);
+  /* This will autostart the service if MOONSHOT_DBUS_NAME is a well-known name.
+   * To inhibit that behavior, add G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START and/or
+   * G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START_AT_CONSTRUCTION
+   */
+  g_proxy = g_dbus_proxy_new_sync(
+      connection,
+      G_DBUS_PROXY_FLAGS_NONE, /* TODO check flags */
+      NULL, /* TODO define our expected interface */
+      MOONSHOT_DBUS_NAME,
+      MOONSHOT_DBUS_PATH,
+      MOONSHOT_DBUS_NAME,
+      NULL, /* no cancellable */
+      &g_error);
 
-    if (g_error_matches(g_error, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED)) {
-        /* Generally this means autolaunch failed because probably DISPLAY is unset*/
-        connection = dbus_launch_moonshot();
-        if (connection != NULL) {
-            g_error_free(g_error);
-            g_error = NULL;
-        }
-    }
-    if (g_error != NULL) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     "DBus error: %s",
-                                     g_error->message);
-        g_error_free (g_error);
-        return NULL;
-    }
+  if (g_error != NULL) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 "DBus error: %s",
+                                 g_error->message);
+    g_error_free (g_error);
+    return NULL;
+  }
 
-    /* This will autostart the service if MOONSHOT_DBUS_NAME is a well-known name.
-     * To inhibit that behavior, add G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START and/or
-     * G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START_AT_CONSTRUCTION
-     */
-    g_proxy = g_dbus_proxy_new_sync(
-                    connection,
-                    G_DBUS_PROXY_FLAGS_NONE, /* TODO check flags */
-                    NULL, /* TODO define our expected interface */
-                    MOONSHOT_DBUS_NAME,
-                    MOONSHOT_DBUS_PATH,
-                    MOONSHOT_DBUS_NAME,
-                    NULL, /* no cancellable */
-                    &g_error);
-
-    if (g_error != NULL) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     "DBus error: %s",
-                                     g_error->message);
-        g_error_free (g_error);
-        return NULL;
-    }
-
-    return g_proxy;
+  return g_proxy;
 }
 
 static GDBusProxy *get_dbus_proxy (MoonshotError **error)
 {
-    static GDBusProxy    *dbus_proxy = NULL;
-    static GStaticMutex   init_lock = G_STATIC_MUTEX_INIT;
+  static GDBusProxy    *dbus_proxy = NULL;
+  static GStaticMutex   init_lock = G_STATIC_MUTEX_INIT;
 
-    g_static_mutex_lock (&init_lock);
+  g_static_mutex_lock (&init_lock);
 
-    if (dbus_proxy == NULL) {
-        /* Make sure GObject is initialised, in case we are the only user
-         * of GObject in the process
-         */
-        g_type_init (); /* harmless but deprecated, may still be needed on CentOS 6 */
-        dbus_proxy = dbus_connect (error);
-    }
+  if (dbus_proxy == NULL) {
+    /* Make sure GObject is initialised, in case we are the only user
+     * of GObject in the process
+     */
+    g_type_init (); /* harmless but deprecated, may still be needed on CentOS 6 */
+    dbus_proxy = dbus_connect (error);
+  }
 
-    /* TODO I think this should only be called if we did not just call dbus_connect()
-     * otherwise ref count will always be n_refs + 1 */
-    if (dbus_proxy != NULL)
-        g_object_ref (dbus_proxy);
+  /* TODO I think this should only be called if we did not just call dbus_connect()
+   * otherwise ref count will always be n_refs + 1 */
+  if (dbus_proxy != NULL)
+    g_object_ref (dbus_proxy);
 
-    g_static_mutex_unlock (&init_lock);
+  g_static_mutex_unlock (&init_lock);
 
-    return dbus_proxy;
+  return dbus_proxy;
 }
 
 int moonshot_get_identity (const char     *nai,
@@ -221,20 +221,20 @@ int moonshot_get_identity (const char     *nai,
                            char          **subject_alt_name_constraint_out,
                            MoonshotError **error)
 {
-    GError     *g_error = NULL;
-    GDBusProxy *dbus_proxy;
-    gboolean    success;
-    GVariant   *result = NULL;
+  GError     *g_error = NULL;
+  GDBusProxy *dbus_proxy;
+  gboolean    success;
+  GVariant   *result = NULL;
 
-    dbus_proxy = get_dbus_proxy (error);
+  dbus_proxy = get_dbus_proxy (error);
 
-    if (*error != NULL)
-        return FALSE;
+  if (*error != NULL)
+    return FALSE;
 
-    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
+  g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
 
-    /* This method consumes the floating parameter GVariant.
-     * Returns null if g_error is set. */
+  /* This method consumes the floating parameter GVariant.
+   * Returns null if g_error is set. */
   result = g_dbus_proxy_call_sync(dbus_proxy,
                                   "GetIdentity",
                                   g_variant_new("(sss)",
@@ -245,74 +245,15 @@ int moonshot_get_identity (const char     *nai,
                                   G_MAXINT, /* infinite timeout */
                                   NULL, /* no cancellable */
                                   &g_error);
-    g_object_unref(dbus_proxy);
+  g_object_unref(dbus_proxy);
 
-    if (g_error != NULL) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     g_error->message);
-        return FALSE;
-    }
+  if (g_error != NULL) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 g_error->message);
+    return FALSE;
+  }
 
-    /* unpack results - allocates space for strings */
-    g_variant_get(result,
-                  "(ssssssb)",
-                  nai_out,
-                  password_out,
-                  server_certificate_hash_out,
-                  ca_certificate_out,
-                  subject_name_constraint_out,
-                  subject_alt_name_constraint_out,
-                  &success);
-    g_variant_unref(result);
-
-    if (success == FALSE) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
-                                     "No identity was returned by the Moonshot "
-                                     "user interface.");
-      /* TODO do we need to free the strings? */
-      return FALSE;
-    }
-
-    return TRUE;
-}
-
-int moonshot_get_default_identity (char          **nai_out,
-                                   char          **password_out,
-                                   char          **server_certificate_hash_out,
-                                   char          **ca_certificate_out,
-                                   char          **subject_name_constraint_out,
-                                   char          **subject_alt_name_constraint_out,
-                                   MoonshotError **error)
-{
-    GError     *g_error = NULL;
-    GDBusProxy *dbus_proxy;
-    gboolean    success = FALSE;
-    GVariant   *result = NULL;
-
-    dbus_proxy = get_dbus_proxy (error);
-
-    if (*error != NULL)
-        return FALSE;
-
-    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
-
-  result = g_dbus_proxy_call_sync(dbus_proxy,
-                                  "GetDefaultIdentity",
-				                          NULL, /* no parameters */
-                                  G_DBUS_CALL_FLAGS_NONE,
-                                  G_MAXINT, /* infinite timeout */
-                                  NULL, /* No cancellable */
-                                  &g_error);
-
-    g_object_unref (dbus_proxy);
-
-    if (g_error != NULL) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     g_error->message);
-        return FALSE;
-    }
-
-    /* unpack results - allocates space for strings */
+  /* unpack results - allocates space for strings */
   g_variant_get(result,
                 "(ssssssb)",
                 nai_out,
@@ -325,14 +266,73 @@ int moonshot_get_default_identity (char          **nai_out,
   g_variant_unref(result);
 
   if (success == FALSE) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
-                                     "No identity was returned by the Moonshot "
-                                     "user interface.");
-        /* TODO do we need to free the strings? */
-        return FALSE;
-    }
+    *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
+                                 "No identity was returned by the Moonshot "
+                                 "user interface.");
+    /* TODO do we need to free the strings? */
+    return FALSE;
+  }
 
-    return TRUE;
+  return TRUE;
+}
+
+int moonshot_get_default_identity (char          **nai_out,
+                                   char          **password_out,
+                                   char          **server_certificate_hash_out,
+                                   char          **ca_certificate_out,
+                                   char          **subject_name_constraint_out,
+                                   char          **subject_alt_name_constraint_out,
+                                   MoonshotError **error)
+{
+  GError     *g_error = NULL;
+  GDBusProxy *dbus_proxy;
+  gboolean    success = FALSE;
+  GVariant   *result = NULL;
+
+  dbus_proxy = get_dbus_proxy (error);
+
+  if (*error != NULL)
+    return FALSE;
+
+  g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
+
+  result = g_dbus_proxy_call_sync(dbus_proxy,
+                                  "GetDefaultIdentity",
+                                  NULL, /* no parameters */
+                                  G_DBUS_CALL_FLAGS_NONE,
+                                  G_MAXINT, /* infinite timeout */
+                                  NULL, /* No cancellable */
+                                  &g_error);
+
+  g_object_unref (dbus_proxy);
+
+  if (g_error != NULL) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 g_error->message);
+    return FALSE;
+  }
+
+  /* unpack results - allocates space for strings */
+  g_variant_get(result,
+                "(ssssssb)",
+                nai_out,
+                password_out,
+                server_certificate_hash_out,
+                ca_certificate_out,
+                subject_name_constraint_out,
+                subject_alt_name_constraint_out,
+                &success);
+  g_variant_unref(result);
+
+  if (success == FALSE) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
+                                 "No identity was returned by the Moonshot "
+                                 "user interface.");
+    /* TODO do we need to free the strings? */
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 int moonshot_install_id_card (const char     *display_name,
@@ -352,75 +352,75 @@ int moonshot_install_id_card (const char     *display_name,
                               int            force_flat_file_store,
                               MoonshotError **error)
 {
-    GError      *g_error = NULL;
-    GDBusProxy  *dbus_proxy;
-    gboolean     success = FALSE;
-    int          i;
-    const char **rules_patterns_strv,
-               **rules_always_confirm_strv,
-               **services_strv;
-    GVariant    *result = NULL;
+  GError      *g_error = NULL;
+  GDBusProxy  *dbus_proxy;
+  gboolean     success = FALSE;
+  int          i;
+  const char **rules_patterns_strv,
+      **rules_always_confirm_strv,
+      **services_strv;
+  GVariant    *result = NULL;
 
-    dbus_proxy = get_dbus_proxy (error);
+  dbus_proxy = get_dbus_proxy (error);
 
-    if (*error != NULL)
-        return FALSE;
+  if (*error != NULL)
+    return FALSE;
 
-    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
-    g_return_val_if_fail (rules_patterns_length == rules_always_confirm_length, FALSE);
+  g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
+  g_return_val_if_fail (rules_patterns_length == rules_always_confirm_length, FALSE);
 
-    /* Marshall array and struct parameters for DBus */
-    rules_patterns_strv = g_malloc ((rules_patterns_length + 1) * sizeof (const char *));
-    rules_always_confirm_strv = g_malloc ((rules_patterns_length + 1) * sizeof (const char *));
-    services_strv = g_malloc ((services_length + 1) * sizeof (const char *));
+  /* Marshall array and struct parameters for DBus */
+  rules_patterns_strv = g_malloc ((rules_patterns_length + 1) * sizeof (const char *));
+  rules_always_confirm_strv = g_malloc ((rules_patterns_length + 1) * sizeof (const char *));
+  services_strv = g_malloc ((services_length + 1) * sizeof (const char *));
 
-    for (i = 0; i < rules_patterns_length; i ++) {
-        rules_patterns_strv[i] = rules_patterns[i];
-        rules_always_confirm_strv[i] = rules_always_confirm[i];
-    }
+  for (i = 0; i < rules_patterns_length; i ++) {
+    rules_patterns_strv[i] = rules_patterns[i];
+    rules_always_confirm_strv[i] = rules_always_confirm[i];
+  }
 
-    for (i = 0; i < services_length; i ++)
-        services_strv[i] = services[i];
+  for (i = 0; i < services_length; i ++)
+    services_strv[i] = services[i];
 
-    rules_patterns_strv[rules_patterns_length] = NULL;
-    rules_always_confirm_strv[rules_patterns_length] = NULL;
-    services_strv[services_length] = NULL;
+  rules_patterns_strv[rules_patterns_length] = NULL;
+  rules_always_confirm_strv[rules_patterns_length] = NULL;
+  services_strv[services_length] = NULL;
 
-    /* '^as' in the variant format string corresponds to the strv type */
-    result = g_dbus_proxy_call_sync(dbus_proxy,
-                                    "InstallIdCard",
-                                    g_variant_new("(ssss^as^as^asssssi)",
-                                                  display_name,
-                                                  user_name,
-                                                  password,
-                                                  realm,
-                                                  rules_patterns_strv,
-                                                  rules_always_confirm_strv,
-                                                  services_strv,
-                                                  ca_cert,
-                                                  subject,
-                                                  subject_alt,
-                                                  server_cert,
-                                                  force_flat_file_store),
-                                    G_DBUS_CALL_FLAGS_NONE,
-                                    G_MAXINT, /* infinite timeout */
-                                    NULL, /* no cancellable */
-                                    &g_error);
-    g_object_unref (dbus_proxy);
-    g_free(rules_patterns_strv);
-    g_free(rules_always_confirm_strv);
-    g_free(services_strv);
+  /* '^as' in the variant format string corresponds to the strv type */
+  result = g_dbus_proxy_call_sync(dbus_proxy,
+                                  "InstallIdCard",
+                                  g_variant_new("(ssss^as^as^asssssi)",
+                                                display_name,
+                                                user_name,
+                                                password,
+                                                realm,
+                                                rules_patterns_strv,
+                                                rules_always_confirm_strv,
+                                                services_strv,
+                                                ca_cert,
+                                                subject,
+                                                subject_alt,
+                                                server_cert,
+                                                force_flat_file_store),
+                                  G_DBUS_CALL_FLAGS_NONE,
+                                  G_MAXINT, /* infinite timeout */
+                                  NULL, /* no cancellable */
+                                  &g_error);
+  g_object_unref (dbus_proxy);
+  g_free(rules_patterns_strv);
+  g_free(rules_always_confirm_strv);
+  g_free(services_strv);
 
-    if (g_error != NULL) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     g_error->message);
-        return FALSE;
-    }
+  if (g_error != NULL) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 g_error->message);
+    return FALSE;
+  }
 
-    g_variant_get(result, "b", &success);
-    g_variant_unref(result);
+  g_variant_get(result, "b", &success);
+  g_variant_unref(result);
 
-    return success;
+  return success;
 }
 
 int moonshot_confirm_ca_certificate (const char           *identity_name,
@@ -429,48 +429,48 @@ int moonshot_confirm_ca_certificate (const char           *identity_name,
                                      int                   hash_len,
                                      MoonshotError       **error)
 {
-    GError     *g_error = NULL;
-    gboolean    success = FALSE;
-    int         confirmed = 99; /* TODO is this for debugging or a meaningful value? */
-    char        hash_str[65];
-    GDBusProxy *dbus_proxy = get_dbus_proxy (error);
-    int         out = 0;
-    int         i;
-    GVariant   *result = NULL;
+  GError     *g_error = NULL;
+  gboolean    success = FALSE;
+  int         confirmed = 99; /* TODO is this for debugging or a meaningful value? */
+  char        hash_str[65];
+  GDBusProxy *dbus_proxy = get_dbus_proxy (error);
+  int         out = 0;
+  int         i;
+  GVariant   *result = NULL;
 
-    if (*error != NULL) {
-        return FALSE;
-    }
+  if (*error != NULL) {
+    return FALSE;
+  }
 
-    g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
+  g_return_val_if_fail (G_IS_DBUS_PROXY (dbus_proxy), FALSE);
 
-    /* Convert hash byte array to string */
-    out = 0;
-    for (i = 0; i < hash_len; i++) {
-        sprintf(&(hash_str[out]), "%02X", ca_hash[i]);
-        out += 2;
-    }
+  /* Convert hash byte array to string */
+  out = 0;
+  for (i = 0; i < hash_len; i++) {
+    sprintf(&(hash_str[out]), "%02X", ca_hash[i]);
+    out += 2;
+  }
 
-    result = g_dbus_proxy_call_sync(dbus_proxy,
-                                    "ConfirmCaCertificate",
-                                    g_variant_new("(sss)",
-                                                  identity_name,
-                                                  realm,
-                                                  hash_str),
-                                    G_DBUS_CALL_FLAGS_NONE,
-                                    G_MAXINT, /* infinite timeout */
-                                    NULL, /* no cancellable */
-                                    &g_error);
-    g_object_unref (dbus_proxy);
+  result = g_dbus_proxy_call_sync(dbus_proxy,
+                                  "ConfirmCaCertificate",
+                                  g_variant_new("(sss)",
+                                                identity_name,
+                                                realm,
+                                                hash_str),
+                                  G_DBUS_CALL_FLAGS_NONE,
+                                  G_MAXINT, /* infinite timeout */
+                                  NULL, /* no cancellable */
+                                  &g_error);
+  g_object_unref (dbus_proxy);
 
-    if (g_error != NULL) {
-        *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
-                                     g_error->message);
-        return FALSE;
-    }
+  if (g_error != NULL) {
+    *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
+                                 g_error->message);
+    return FALSE;
+  }
 
-    g_variant_get(result, "(ib)", &confirmed, &success);
-    g_variant_unref(result);
+  g_variant_get(result, "(ib)", &confirmed, &success);
+  g_variant_unref(result);
 
-    return confirmed;
+  return confirmed;
 }

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -211,6 +211,9 @@ static GDBusProxy *get_dbus_proxy (MoonshotError **error)
   return dbus_proxy;
 }
 
+/* Output strings are always set to non-null, even if no identity is returned.
+ * These must be freed with moonshot_free() by the caller.
+ */
 int moonshot_get_identity (const char     *nai,
                            const char     *password,
                            const char     *service,
@@ -267,16 +270,20 @@ int moonshot_get_identity (const char     *nai,
   g_variant_unref(result);
 
   if (success == FALSE) {
+    /* On failure, the output strings are non-null (pointing to "" strings). The
+     * caller will free them. */
     *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
                                  "No identity was returned by the Moonshot "
                                  "user interface.");
-    /* TODO do we need to free the strings? */
     return FALSE;
   }
 
   return TRUE;
 }
 
+/* Output strings are always set to non-null, even if no identity is returned.
+ * These must be freed with moonshot_free() by the caller.
+ */
 int moonshot_get_default_identity (char          **nai_out,
                                    char          **password_out,
                                    char          **server_certificate_hash_out,
@@ -329,7 +336,9 @@ int moonshot_get_default_identity (char          **nai_out,
     *error = moonshot_error_new (MOONSHOT_ERROR_NO_IDENTITY_SELECTED,
                                  "No identity was returned by the Moonshot "
                                  "user interface.");
-    /* TODO do we need to free the strings? */
+    g_error_free(g_error);
+    /* On failure, the output strings are non-null (pointing to "" strings). The
+     * caller will free them. */
     return FALSE;
   }
 
@@ -415,6 +424,7 @@ int moonshot_install_id_card (const char     *display_name,
   if (g_error != NULL) {
     *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
                                  g_error->message);
+    g_error_free(g_error);
     return FALSE;
   }
 
@@ -467,6 +477,7 @@ int moonshot_confirm_ca_certificate (const char           *identity_name,
   if (g_error != NULL) {
     *error = moonshot_error_new (MOONSHOT_ERROR_IPC_ERROR,
                                  g_error->message);
+    g_error_free(g_error);
     return FALSE;
   }
 

--- a/moonshot-ui.spec.in
+++ b/moonshot-ui.spec.in
@@ -9,14 +9,13 @@ URL:            http://www.project-moonshot.org/
 Source0:	%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
 
-BuildRequires:		glib-devel
+BuildRequires:		glib2-devel
 BuildRequires:  	gtk2-devel
-BuildRequires: libgee-devel
+BuildRequires:    libgee-devel
 BuildRequires:  	dbus-devel
-BuildRequires: 		dbus-glib-devel
 BuildRequires: 		desktop-file-utils
 BuildRequires: 		shared-mime-info
-BuildRequires: gnome-keyring-devel
+BuildRequires:    gnome-keyring-devel
 
 Requires:        desktop-file-utils, shared-mime-info, dbus-x11
 

--- a/src/moonshot-identity-manager-app.vala
+++ b/src/moonshot-identity-manager-app.vala
@@ -243,8 +243,8 @@ public class IdentityManagerApp {
                 }
                 request.return_identity(identity);
 // The following occasionally causes the app to exit without sending the dbus
-// reply, so for now we just don't exit
 //                if (!explicitly_launched)
+// reply, so for now we just don't exit
 //                    Idle.add(() => { Gtk.main_quit(); return false; } );
                 return false;
             }

--- a/src/moonshot-identity-manager-app.vala
+++ b/src/moonshot-identity-manager-app.vala
@@ -243,8 +243,8 @@ public class IdentityManagerApp {
                 }
                 request.return_identity(identity);
 // The following occasionally causes the app to exit without sending the dbus
-//                if (!explicitly_launched)
 // reply, so for now we just don't exit
+//                if (!explicitly_launched)
 //                    Idle.add(() => { Gtk.main_quit(); return false; } );
                 return false;
             }

--- a/src/moonshot-server-linux.vala
+++ b/src/moonshot-server-linux.vala
@@ -47,6 +47,14 @@ public class MoonshotServer : Object {
         this.parent_app = app;
     }
 
+    /**
+     * DBus method "ShowUi"
+     *
+     * The return data signature is the declared "out" parameters plus the return
+     * value of this method.
+     *
+     * In this case, that is (b).
+     */
     public bool show_ui()
     {
         logger.trace("MoonshotServer.show_ui");
@@ -62,6 +70,14 @@ public class MoonshotServer : Object {
         return true;
     }
 
+    /**
+     * DBus method "GetIdentity"
+     *
+     * The return data signature is the declared "out" parameters plus the return
+     * value of this method.
+     *
+     * In this case, that is (ssssssb).
+     */
     public async bool get_identity(string nai,
                                    string password,
                                    string service,
@@ -127,6 +143,14 @@ public class MoonshotServer : Object {
         return false;
     }
 
+    /**
+     * DBus method "GetDefaultIdentity"
+     *
+     * The return data signature is the declared "out" parameters plus the return
+     * value of this method.
+     *
+     * In this case, that is (ssssssb).
+     */
     public async bool get_default_identity(out string nai_out,
                                            out string password_out,
                                            out string server_certificate_hash,
@@ -177,6 +201,14 @@ public class MoonshotServer : Object {
         return false;
     }
 
+    /**
+     * DBus method "InstallIdCard"
+     *
+     * The return data signature is the declared "out" parameters plus the return
+     * value of this method.
+     *
+     * In this case, that is (b).
+     */
     public bool install_id_card(string   display_name,
                                 string   user_name,
                                 string   ?password,
@@ -242,6 +274,14 @@ public class MoonshotServer : Object {
     }
 
 
+    /**
+     * DBus method "InstallFromFile"
+     *
+     * The return data signature is the declared "out" parameters plus the return
+     * value of this method.
+     *
+     * In this case, that is (b).
+     */
     public int install_from_file(string file_name)
     {
         var webp = new WebProvisioning.Parser(file_name);
@@ -298,6 +338,14 @@ public class MoonshotServer : Object {
         return installed_cards;
     }
 
+    /**
+     * DBus method "ConfirmCaCertificate"
+     *
+     * The return data signature is the declared "out" parameters plus the return
+     * value of this method.
+     *
+     * In this case, that is (ib).
+     */
     public async bool confirm_ca_certificate(string nai,
                                              string realm,
                                              string ca_hash,


### PR DESCRIPTION
This addresses #20 by removing dbus-glib and using the GDBus components of the gio library for libmoonshot. Also removes direct use of libdbus.

This is a mostly one-for-one replacement of the library calls. Some obviously obsolete behavior has been removed, but there is room to revisit some architectural decisions. That is not the goal of this pull request - this is just to get rid of the old library.

It does this both for Linux and for Darwin - the latter is untested. If we're still building for Mac, we will need to test this. There's no sense keeping dbus-glib support in the makefile / configure scripts because the code is now incompatible.

The tests and example client run, but this has not been extensively tested.