### PR TITLE
Manage DBus launching without dbus-launch script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -199,7 +199,8 @@ $(dbus_bus_file): $(dbus_bus_in_file) Makefile
 dbuscfgdir = $(pkgdatadir)/dbus
 dist_dbuscfg_DATA = $(dbus_service_file) $(dbus_bus_file)
 
-AM_CPPFLAGS += -DMOONSHOT_DBUS_BUS_CONF='"$(pkgdatadir)/dbus/org.janet.Moonshot.conf"'
+AM_CPPFLAGS += -DMOONSHOT_DBUS_BUS_CONF='"$(pkgdatadir)/dbus/org.janet.Moonshot.conf"' \
+               -DMOONSHOT_DBUS_DAEMON='"@DBUS_DAEMON@"'
 
 libmoonshot_libmoonshot_la_SOURCES += libmoonshot/libmoonshot-dbus.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ lib_LTLIBRARIES = libmoonshot/libmoonshot.la
 bin_PROGRAMS = \
          src/moonshot \
          src/moonshot-webp
-pkglibexec_SCRIPTS = moonshot-dbus-launch
 
 dist_pkgdata_DATA = webprovisioning/default-identity.msht
 dist_moonshotsysconf_DATA=flatstore-users
@@ -19,8 +18,7 @@ AM_CFLAGS = -g -O0 -Wall
 AM_CPPFLAGS =  \
 	-include config.h \
 	-DLOCALEDIR=\""$(localedir)"\" \
-	-DMOONSHOT_LAUNCH_SCRIPT='"$(pkglibexecdir)/moonshot-dbus-launch"' \
-        -DMOONSHOT_FLATSTORE_USERS='"$(moonshotsysconfdir)/flatstore-users"' \
+	-DMOONSHOT_FLATSTORE_USERS='"$(moonshotsysconfdir)/flatstore-users"' \
 	-I$(top_srcdir)/libmoonshot \
 	-I$(top_builddir)/libmoonshot
 
@@ -170,19 +168,38 @@ endif
 
 if IPC_DBUS
 
-# DBus service file
-dbusservicedir = $(datadir)/dbus-1/services
+# Script to expand makefile variables.
+# Note: @bindir[@] is does what \@bindir\@ appears to do, but \@ is
+# not POSIX-compliant
+in_substitute = sed \
+	-e 's|@bindir[@]|$(bindir)|g' \
+	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g'
+
+# DBus service def file. This will be symlinked into ${datadir}/dbus-1/services by
+# the packaging scripts.
 if  OS_MACOS
-dbusservice_in_files = org.janet.Moonshot.service.mac
-dbusservice_DATA = $(dbusservice_in_files:.service.mac=.service)
+dbus_service_in_file = org.janet.Moonshot.service.mac
+dbus_service_file = $(dbusservice_in_file:.service.mac=.service)
 else
-dbusservice_in_files = org.janet.Moonshot.service.in
-dbusservice_DATA = $(dbusservice_in_files:.service.in=.service)
+dbus_service_in_file = org.janet.Moonshot.service.in
+dbus_service_file = $(dbus_service_in_file:.service.in=.service)
 endif
 
-# Rule to make the service file with bindir expanded
-$(dbusservice_DATA): $(dbusservice_in_files) Makefile
-	@sed -e "s|\@bindir\@|$(bindir)|" $< > $@
+# DBus bus configuration file, used for launching our own bus when the session bus
+# is not available.
+dbus_bus_in_file = org.janet.Moonshot.conf.in
+dbus_bus_file = $(dbus_bus_in_file:.conf.in=.conf)
+
+# Rules to expand .in files into service/conf files
+$(dbus_service_file): $(dbus_service_in_file) Makefile
+	@$(in_substitute) $< > $@
+$(dbus_bus_file): $(dbus_bus_in_file) Makefile
+	@$(in_substitute) $< > $@
+
+dbuscfgdir = $(pkgdatadir)/dbus
+dist_dbuscfg_DATA = $(dbus_service_file) $(dbus_bus_file)
+
+AM_CPPFLAGS += -DMOONSHOT_DBUS_BUS_CONF='"$(pkgdatadir)/dbus/org.janet.Moonshot.conf"'
 
 libmoonshot_libmoonshot_la_SOURCES += libmoonshot/libmoonshot-dbus.c
 
@@ -197,10 +214,10 @@ if GIO_VAPI_USES_ARRAYS
 AM_VALAFLAGS += --define=GIO_VAPI_USES_ARRAYS
 endif
 
-EXTRA_DIST = webprovisioning/moonshot.xml $(dbusservice_in_files) \
+EXTRA_DIST = webprovisioning/moonshot.xml $(dbus_service_in_file) \
+    $(dbus_bus_in_file) \
 	webprovisioning/complex-test.msht webprovisioning/sample.msht \
 	README.webprovisioning README.windows \
-	moonshot-dbus-launch \
 	moonshot-ui.spec \
 	vapi/moonshot-gnome-keyring.vapi libmoonshot/libmoonshot.vapi
 
@@ -222,7 +239,6 @@ tests_basic_CPPFLAGS = $(moonshot_CFLAGS) $(AM_CPPFLAGS)
 tests_basic_LDADD = ${top_builddir}/libmoonshot/libmoonshot.la $(moonshot_LIBS)
 
 ##if OS_LINUX
-##install-data-hook:
 ##	"${UPDATE_MIME_DATABASE}" $(datadir)/mime
 ##	"${UPDATE_DESKTOP_DATABASE}" $(datadir)/applications
 ##uninstall-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.63])
 AC_INIT([Moonshot-ui],
-        [1.0.5],
+        [1.0.6],
         [moonshot-community@jiscmail.ac.uk],
         [moonshot-ui],
         [http://www.project-moonshot.org/])
@@ -24,6 +24,7 @@ AC_CHECK_FUNCS_ONCE(geteuid getpwuid)
 # Checks for programs.
 PKG_PROG_PKG_CONFIG([0.23])
 AC_PROG_CC
+AC_PROG_LN_S
 AM_PROG_CC_C_O
 AM_PROG_VALAC([0.9])
 
@@ -223,8 +224,8 @@ AC_SUBST(MOONSHOT_WEBP)
 # Dependencies
 PKG_CHECK_MODULES(moonshot,[
         atk >= 1.20
-        glib-2.0 >= 2.22
-        gobject-2.0 >= 2.22
+        glib-2.0 >= 2.26
+        gobject-2.0 >= 2.26
         libssl
         $GTK_VERSION
         $GEE_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,6 @@ AM_CONDITIONAL([OS_MACOS], [test "$macos" = "yes"])
 
 AM_CONDITIONAL([IPC_MSRPC], [test "$SERVER_IPC_MODULE" = "msrpc-glib2-1.0"])
 AM_CONDITIONAL([IPC_DBUS], [test "$SERVER_IPC_MODULE" != "msrpc-glib2-1.0"])
-AM_CONDITIONAL([IPC_GDBUS], [test "$SERVER_IPC_MODULE" = "gio-2.0"])
 
 vala_version=`$VALAC --version | sed 's/Vala  *//'`
 AS_VERSION_COMPARE(["$vala_version"], [0.11.1],
@@ -207,6 +206,14 @@ if test "$linux" = "yes"; then
 *** tool. Web provisioning files could not be automatically installed.])
   fi
 fi
+
+AM_COND_IF([IPC_DBUS],
+           [AC_ARG_VAR(DBUS_DAEMON, [Location of dbus-daemon executable])
+            AC_PATH_PROG([DBUS_DAEMON], [dbus-daemon], [no])
+            if test "$DBUS_DAEMON" = "no"; then
+              AC_MSG_ERROR([
+*** Could not find the dbus-daemon executable. This is required.])
+            fi ])
 
 MOONSHOT_APP="$bindir/moonshot"
 MOONSHOT_WEBP="$bindir/moonshot-webp"

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -211,6 +211,7 @@ static GDBusConnection *dbus_connect(MoonshotError **error)
   if (connection == NULL) {
     /* That failed. Try to start our own session bus and connect. */
     g_error_free(g_error); /* ignore that error */
+    g_error = NULL;
 
     private_bus_address = dbus_launch_bus(error);
     if (private_bus_address == NULL)

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -639,7 +639,7 @@ int moonshot_install_id_card (const char     *display_name,
     return FALSE;
   }
 
-  g_variant_get(result, "b", &success);
+  g_variant_get(result, "(b)", &success);
   g_variant_unref(result);
 
   return success;

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -79,6 +79,7 @@ static gchar *dbus_read_bus_addr(gint fd, MoonshotError **error)
 {
   gchar dbus_addr[MOONSHOT_DBUS_ADDR_MAX_LEN];
   ssize_t dbus_addr_len = -1;
+  gchar *result = NULL;
 
   /* Read the bus address from the fine descriptor. It should have a trailing '\n' */
   dbus_addr_len = read(fd, dbus_addr, sizeof(dbus_addr));
@@ -101,7 +102,15 @@ static gchar *dbus_read_bus_addr(gint fd, MoonshotError **error)
     return NULL;
   }
 
-  return g_strdup(dbus_addr); /* make a copy to send back to the caller */
+  result = g_strdup(dbus_addr); /* make a copy to send back to the caller */
+  if (result == NULL) {
+    /* this is unlikely to succeed if we just failed to dup a string, but at least try */
+    *error = moonshot_error_new(MOONSHOT_ERROR_IPC_ERROR,
+                                "Error copying bus address");
+    return NULL;
+  }
+
+  return result;
 }
 
 /**

--- a/libmoonshot/libmoonshot-dbus.c
+++ b/libmoonshot/libmoonshot-dbus.c
@@ -159,15 +159,15 @@ static gchar *dbus_read_bus_addr(gint fd, MoonshotError **error)
  */
 static void dbus_terminate_bus(MoonshotDBusBus *bus)
 {
-  if (bus) {
-    close(bus->stdout);
-    if (bus->pid > 0)
-      kill(bus->pid, SIGTERM);
-    g_spawn_close_pid(bus->pid);
-    if (bus->address)
-      g_free(bus->address);
-    g_free(bus);
-  }
+  g_return_if_fail(bus != NULL);
+
+  close(bus->stdout);
+  if (bus->pid > 0)
+    kill(bus->pid, SIGTERM);
+  g_spawn_close_pid(bus->pid);
+  if (bus->address)
+    g_free(bus->address);
+  g_free(bus);
 }
 
 /**
@@ -185,7 +185,7 @@ static MoonshotDBusBus *dbus_launch_bus(MoonshotError **error)
   MoonshotDBusBus *bus;
   GError *g_error = NULL;
   gchar *dbus_daemon_argv[] = {
-    "/usr/bin/dbus-daemon",
+    MOONSHOT_DBUS_DAEMON,
     "--nofork",
     "--print-address",
     "--nopidfile",
@@ -257,7 +257,9 @@ static gboolean dbus_connection_uses_session_bus(MoonshotDBusConnection *conn)
  */
 static void dbus_disconnect(MoonshotDBusConnection *conn)
 {
-  if (conn)
+  g_return_if_fail(conn != NULL);
+
+  if (conn->connection)
     g_dbus_connection_close_sync(conn->connection, NULL, NULL);
 
   if (conn->bus) {

--- a/moonshot-dbus-launch
+++ b/moonshot-dbus-launch
@@ -1,8 +1,0 @@
-#!/bin/sh
-mkdir ${HOME}/.cache 2>/dev/null
-eval `dbus-launch --sh-syntax`
-trap "kill $DBUS_SESSION_BUS_PID" hup pipe int term
-echo $DBUS_SESSION_BUS_ADDRESS
-read foo
-kill $DBUS_SESSION_BUS_PID
-

--- a/moonshot-ui.spec.in
+++ b/moonshot-ui.spec.in
@@ -1,6 +1,6 @@
 Name:           @PACKAGE@
 Version:        @VERSION@
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Moonshot Federated Identity User Interface
 
 Group:          Security Tools
@@ -11,11 +11,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:		glib2-devel
 BuildRequires:  	gtk2-devel
-BuildRequires:    libgee-devel
+BuildRequires:      libgee-devel
 BuildRequires:  	dbus-devel
 BuildRequires: 		desktop-file-utils
 BuildRequires: 		shared-mime-info
-BuildRequires:    gnome-keyring-devel
+BuildRequires:      gnome-keyring-devel
 
 Requires:        desktop-file-utils, shared-mime-info, dbus-x11
 
@@ -34,6 +34,8 @@ make %{?_smp_mflags}
 %install
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
+mkdir -p ${_datadir}/dbus-1/services
+ln -s ${_datadir}/moonshot-ui/dbus/org.janet.Moonshot.service ${_datadir}/dbus-1/services/org.janet.Moonshot.service
 
 
 %clean

--- a/moonshot-ui.spec.in
+++ b/moonshot-ui.spec.in
@@ -17,7 +17,7 @@ BuildRequires: 		desktop-file-utils
 BuildRequires: 		shared-mime-info
 BuildRequires:      gnome-keyring-devel
 
-Requires:        desktop-file-utils, shared-mime-info, dbus-x11
+Requires:        desktop-file-utils, shared-mime-info, dbus
 
 %description
 

--- a/moonshot-ui.spec.in
+++ b/moonshot-ui.spec.in
@@ -11,11 +11,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:		glib2-devel
 BuildRequires:  	gtk2-devel
-BuildRequires:      libgee-devel
+BuildRequires:          libgee-devel
 BuildRequires:  	dbus-devel
 BuildRequires: 		desktop-file-utils
 BuildRequires: 		shared-mime-info
-BuildRequires:      gnome-keyring-devel
+BuildRequires:          libgnome-keyring-devel
 
 Requires:        desktop-file-utils, shared-mime-info, dbus
 
@@ -34,8 +34,8 @@ make %{?_smp_mflags}
 %install
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
-mkdir -p ${_datadir}/dbus-1/services
-ln -s ${_datadir}/moonshot-ui/dbus/org.janet.Moonshot.service ${_datadir}/dbus-1/services/org.janet.Moonshot.service
+mkdir -p $RPM_BUILD_ROOT%{_datadir}/dbus-1/services
+ln -s ../../moonshot-ui/dbus/org.janet.Moonshot.service $RPM_BUILD_ROOT%{_datadir}/dbus-1/services/org.janet.Moonshot.service
 
 
 %clean
@@ -62,10 +62,9 @@ Requires: moonshot-ui  = %{version}-%{release}
 %{_bindir}/moonshot
 %{_bindir}/moonshot-webp
 %{_datadir}/applications/*
-%{_datadir}/dbus-1/*
+%{_datadir}/dbus-1/services/*
 %{_datadir}/mime/packages/*
 %{_datadir}/moonshot-ui
-%{_libexecdir}/moonshot-ui/moonshot-dbus-launch
 %{_libdir}/libmoonshot.so.*
 %config(noreplace) %{_sysconfdir}/moonshot/*
 %doc webprovisioning/default-identity.msht

--- a/org.janet.Moonshot.conf.in
+++ b/org.janet.Moonshot.conf.in
@@ -1,0 +1,18 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type> <!-- imitate a session bus -->
+  <listen>unix:tmpdir=/tmp</listen>
+  <auth>EXTERNAL</auth>
+  <servicedir>@pkgdatadir@/dbus</servicedir>
+
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+    <!-- Allow anyone to own anything -->
+    <allow own="*"/>
+  </policy>
+
+</busconfig>

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -27,15 +27,27 @@ gpointer test_func (gpointer data)
                                              &subject_alt_name_constraint,
                                              error);
 
-    /*if (success)
-        g_print ("Got id: %s %s\n", nai, password);*/
+    if (success) {
+      success = (nai != NULL)
+                && (password != NULL)
+                && (server_certificate_hash != NULL)
+                && (ca_certificate != NULL)
+                && (subject_name_constraint != NULL)
+                && (subject_alt_name_constraint != NULL);
 
-    moonshot_free (nai);
-    moonshot_free (password);
-    moonshot_free (server_certificate_hash);
-    moonshot_free (ca_certificate);
-    moonshot_free (subject_name_constraint);
-    moonshot_free (subject_alt_name_constraint);
+      if (nai)
+        moonshot_free (nai);
+      if (password)
+        moonshot_free (password);
+      if (server_certificate_hash)
+        moonshot_free (server_certificate_hash);
+      if (ca_certificate)
+        moonshot_free (ca_certificate);
+      if (subject_name_constraint)
+        moonshot_free (subject_name_constraint);
+      if (subject_alt_name_constraint)
+        moonshot_free (subject_alt_name_constraint);
+    }
 
     return GINT_TO_POINTER (success);
 }


### PR DESCRIPTION
This resolves #16, eliminating use of the X11-specific `dbus-launch`. This allows deployment without X11, though the current identity selector will not work without it. In principle, `moonshot-webp` should.

Instead of launching a full session bus with `dbus-launch`, this uses `dbus-daemon` to launch our own custom, private DBus bus instance. This identifies itself as a session bus, but only runs the `org.janet.Moonshot` service -- it does*not* include the system-wide DBus services. In principle this should probably not have its type set to session -- it's not a session bus -- but that would require work to allow the identity selector to work with a non-standard bus type. Since no one else will be using this private bus, this should be a reasonable situation.

This makes a good faith effort not to break builds on Darwin (OSX), but has been neither built nor tested on that platform.

This is branched from jennifer/eliminate-dbus-glib, so should be reviewed and merged after #21.